### PR TITLE
Task 7

### DIFF
--- a/project/__init__.py
+++ b/project/__init__.py
@@ -12,3 +12,9 @@ from project.rpq import *
 
 import project.cfg
 from project.cfg import *
+
+import project.rsm
+from project.rsm import *
+
+import project.ecfg
+from project.ecfg import *

--- a/project/ecfg.py
+++ b/project/ecfg.py
@@ -1,0 +1,63 @@
+from typing import NamedTuple, AbstractSet
+
+from pyformlang.cfg import Variable
+from pyformlang.regular_expression import Regex
+
+from project.rsm import RSM
+
+
+class ECFG(NamedTuple):
+
+    start_symbol: Variable
+    variables: AbstractSet[Variable]
+    productions: dict[Variable, Regex]
+
+
+def get_ecfg_from_text(text: str, start_symbol: Variable = Variable("S")):
+    """Constructs Extended Context Free Grammar from text representation.
+
+    :param text: Text representation of extended Context Free Grammar.
+    :param start_symbol: Start symbol of given extended Context Free Grammar.
+    :return: Extended Context Free Grammar.
+    """
+    variables = set()
+    productions = dict()
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        content = [str.strip(elem) for elem in line.split("->")]
+        head, body = content
+        head = Variable(head)
+        body = Regex(body)
+        variables.add(head)
+        productions[head] = body
+    return ECFG(
+        start_symbol=start_symbol,
+        variables=variables,
+        productions=productions,
+    )
+
+
+def get_ecfg_from_file(
+        file: str, start_symbol: Variable = Variable("S")
+) -> ECFG:
+    """Constructs Extended Context Free Grammar from file.
+
+    :param file: Path to file.
+    :param start_symbol: Start symbol of given extended Context Free Grammar.
+    :return: Extended Context Free Grammar.
+    """
+    with open(file) as f:
+        return get_ecfg_from_text(f.read(), start_symbol=start_symbol)
+
+
+def convert_ecfg_to_rsm(ecfg: ECFG) -> RSM:
+    """Converts Extended Context Free Grammar to Recursive State Machine.
+
+    :param ecfg: Given extended Context Free Grammar.
+    :return: Recursive State Machine from extended Context Free Grammar.
+    """
+    return RSM(
+        start_symbol=ecfg.start_symbol,
+        boxes={h: r.to_epsilon_nfa().to_deterministic() for h, r in ecfg.productions.items()},
+    )

--- a/project/ecfg.py
+++ b/project/ecfg.py
@@ -38,9 +38,7 @@ def get_ecfg_from_text(text: str, start_symbol: Variable = Variable("S")):
     )
 
 
-def get_ecfg_from_file(
-        file: str, start_symbol: Variable = Variable("S")
-) -> ECFG:
+def get_ecfg_from_file(file: str, start_symbol: Variable = Variable("S")) -> ECFG:
     """Constructs Extended Context Free Grammar from file.
 
     :param file: Path to file.
@@ -59,5 +57,8 @@ def convert_ecfg_to_rsm(ecfg: ECFG) -> RSM:
     """
     return RSM(
         start_symbol=ecfg.start_symbol,
-        boxes={h: r.to_epsilon_nfa().to_deterministic() for h, r in ecfg.productions.items()},
+        boxes={
+            h: r.to_epsilon_nfa().to_deterministic()
+            for h, r in ecfg.productions.items()
+        },
     )

--- a/project/ecfg.py
+++ b/project/ecfg.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple, AbstractSet
+from typing import NamedTuple, AbstractSet, Dict
 
 from pyformlang.cfg import Variable
 from pyformlang.regular_expression import Regex
@@ -10,7 +10,7 @@ class ECFG(NamedTuple):
 
     start_symbol: Variable
     variables: AbstractSet[Variable]
-    productions: dict[Variable, Regex]
+    productions: Dict[Variable, Regex]
 
 
 def get_ecfg_from_text(text: str, start_symbol: Variable = Variable("S")):

--- a/project/regex.py
+++ b/project/regex.py
@@ -1,15 +1,17 @@
+from typing import Union
+
 from pyformlang.regular_expression import Regex
 from pyformlang.finite_automaton import DeterministicFiniteAutomaton
 
 
-def regex_to_min_dfa(regex_str: str) -> DeterministicFiniteAutomaton:
+def regex_to_min_dfa(regex: Union[str, Regex]) -> DeterministicFiniteAutomaton:
     """Constructs minimal DFA based on the given regex.
 
-    :param regex_str: String representation of a regex.
+    :param regex: String representation of a regex.
     :return: DFA corresponding to the given regex.
     """
-
-    regex = Regex(regex_str)
+    if isinstance(regex, str):
+        regex = Regex(regex)
     epsilon_nfa = regex.to_epsilon_nfa()
     dfa = epsilon_nfa.to_deterministic()
     return dfa.minimize()

--- a/project/rsm.py
+++ b/project/rsm.py
@@ -1,0 +1,19 @@
+from typing import NamedTuple, Dict
+
+from pyformlang.cfg import Variable
+from pyformlang.finite_automaton import DeterministicFiniteAutomaton
+
+
+class RSM(NamedTuple):
+    start_symbol: Variable
+    boxes: Dict[Variable, DeterministicFiniteAutomaton]
+
+    def minimize(self):
+        """Minimizes Recursive State Machine.
+
+        :return: Minimized Recursive State Machine.
+        """
+        return RSM(
+            start_symbol=self.start_symbol,
+            boxes={v: a.minimize() for v, a in self.boxes.items()},
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ networkx
 pre-commit
 pydot
 pyformlang
-pytest
+pytest==7.1.3
 scipy

--- a/tests/test_convert_cfg_to_ecfg.py
+++ b/tests/test_convert_cfg_to_ecfg.py
@@ -7,7 +7,9 @@ from project import convert_cfg_to_ecfg, regex_to_min_dfa
 def check(cfg_as_text, expected_productions):
     ecfg = convert_cfg_to_ecfg(CFG.from_text(cfg_as_text))
     assert all(
-        regex_to_min_dfa(ecfg.productions[production]).is_equivalent_to(regex_to_min_dfa(expected_productions[production]))
+        regex_to_min_dfa(ecfg.productions[production]).is_equivalent_to(
+            regex_to_min_dfa(expected_productions[production])
+        )
         for production in ecfg.productions
     )
 

--- a/tests/test_convert_cfg_to_ecfg.py
+++ b/tests/test_convert_cfg_to_ecfg.py
@@ -1,0 +1,32 @@
+from pyformlang.cfg import CFG, Variable
+from pyformlang.regular_expression import Regex
+
+from project import convert_cfg_to_ecfg, regex_to_min_dfa
+
+
+def check(cfg_as_text, expected_productions):
+    ecfg = convert_cfg_to_ecfg(CFG.from_text(cfg_as_text))
+    assert all(
+        regex_to_min_dfa(ecfg.productions[production]).is_equivalent_to(regex_to_min_dfa(expected_productions[production]))
+        for production in ecfg.productions
+    )
+
+
+def test_convert_cfg_to_ecfg_empty():
+    cfg_as_text = ""
+    expected_productions = {}
+    check(cfg_as_text, expected_productions)
+
+
+def test_convert_cfg_to_ecfg_1():
+    cfg_as_text = "S -> x"
+    expected_productions = {Variable("S"): Regex("x")}
+    check(cfg_as_text, expected_productions)
+
+
+def test_convert_cfg_to_ecfg_2():
+    cfg_as_text = """
+        S -> b|S*
+    """
+    expected_productions = {Variable("S"): Regex("b|S*")}
+    check(cfg_as_text, expected_productions)

--- a/tests/test_convert_ecfg_to_rsm.py
+++ b/tests/test_convert_ecfg_to_rsm.py
@@ -1,0 +1,29 @@
+from project import convert_ecfg_to_rsm, regex_to_min_dfa, get_ecfg_from_text
+
+
+def check(ecfg, rsm):
+    assert all(
+        regex_to_min_dfa(ecfg.productions[v]).is_equivalent_to(rsm.boxes[v].minimize())
+        for v in ecfg.productions
+    )
+
+
+def test_convert_ecfg_to_rsm_1():
+    ecfg_as_text = "S -> x"
+    ecfg = get_ecfg_from_text(ecfg_as_text)
+    rsm = convert_ecfg_to_rsm(ecfg)
+    check(ecfg, rsm)
+
+
+def test_convert_ecfg_to_rsm_2():
+    ecfg_as_text = "S -> b|S*"
+    ecfg = get_ecfg_from_text(ecfg_as_text)
+    rsm = convert_ecfg_to_rsm(ecfg)
+    check(ecfg, rsm)
+
+
+def test_convert_ecfg_to_rsm_3():
+    ecfg_as_text = "S -> (a) | (b* S)"
+    ecfg = get_ecfg_from_text(ecfg_as_text)
+    rsm = convert_ecfg_to_rsm(ecfg)
+    check(ecfg, rsm)

--- a/tests/test_get_ecfg_from_file_and_text.py
+++ b/tests/test_get_ecfg_from_file_and_text.py
@@ -1,0 +1,35 @@
+import os
+
+from pyformlang.cfg import Variable
+
+from project import get_ecfg_from_file, get_ecfg_from_text
+from tests.test_get__cfg_from_file import create_temp_file
+
+
+def test_get_ecfg_from_file_not_empty():
+    ecfg_file = create_temp_file("not_empty_ecfg.txt", "S -> x")
+    ecfg = get_ecfg_from_file(ecfg_file)
+    expected_productions = {Variable("S"): "x"}
+    productions = {left: str(rule) for left, rule in ecfg.productions.items()}
+    assert productions == expected_productions
+    os.remove(ecfg_file)
+
+
+def test_get_ecfg_from_file_empty():
+    ecfg_file = create_temp_file("empty_ecfg.txt", "")
+    ecfg = get_ecfg_from_file(ecfg_file)
+    expected_productions = {}
+    assert ecfg.productions == expected_productions
+    os.remove(ecfg_file)
+
+def test_get_ecfg_from_text_not_empty():
+    ecfg = get_ecfg_from_text("S -> x")
+    expected_productions = {Variable("S"): "x"}
+    productions = {left: str(rule) for left, rule in ecfg.productions.items()}
+    assert productions == expected_productions
+
+
+def test_get_ecfg_from_text_empty():
+    ecfg = get_ecfg_from_text("")
+    expected_productions = {}
+    assert ecfg.productions == expected_productions

--- a/tests/test_get_ecfg_from_file_and_text.py
+++ b/tests/test_get_ecfg_from_file_and_text.py
@@ -22,6 +22,7 @@ def test_get_ecfg_from_file_empty():
     assert ecfg.productions == expected_productions
     os.remove(ecfg_file)
 
+
 def test_get_ecfg_from_text_not_empty():
     ecfg = get_ecfg_from_text("S -> x")
     expected_productions = {Variable("S"): "x"}

--- a/tests/test_minimize_rsm.py
+++ b/tests/test_minimize_rsm.py
@@ -1,0 +1,29 @@
+from project import get_ecfg_from_text, convert_ecfg_to_rsm
+
+
+def check(minimized_rsm):
+    assert all(
+        automaton.is_equivalent_to(automaton.minimize())
+        for automaton in minimized_rsm.boxes.values()
+    )
+
+
+def test_minimize_rsm_1():
+    ecfg_as_text = ""
+    rsm = convert_ecfg_to_rsm(get_ecfg_from_text(ecfg_as_text))
+    minimized = rsm.minimize()
+    check(minimized)
+
+
+def test_minimize_rsm_2():
+    ecfg_as_text = "S -> x"
+    rsm = convert_ecfg_to_rsm(get_ecfg_from_text(ecfg_as_text))
+    minimized = rsm.minimize()
+    check(minimized)
+
+
+def test_minimize_rsm_3():
+    ecfg_as_text = "S -> (a) | (b* S)"
+    rsm = convert_ecfg_to_rsm(get_ecfg_from_text(ecfg_as_text))
+    minimized = rsm.minimize()
+    check(minimized)


### PR DESCRIPTION
# Задача 7. Рекурсивные конечные автоматы

* **Мягкий дедлайн**: 30.10.2022, 23:59
* **Жёсткий дедлайн**: 02.11.2022, 23:59
* Полный балл: 5

## Расширенные контекстно-свободные грамматики (ECFG)

В дополнение к существующему в pyformalng формату описания КС грамматик зафиксируем следующий формат.
- Для каждого нетерминала существует ровно одно правило.
- На одной строке содержится ровно одно правило.
- Правило --- это нетерминал и регулярное выражение над терминалами и нетерминалами, принимаемое pyformalng, разделенные ``` -> ```. Например: ``` S -> a | b* S ```

Будем называть данный формат расширенными контекстно-свободными грамматиками (Extended Context-Free Grammars, ECFG).

## Задача

- [x] Реализовать тип для представления рекурсивных конечных автоматов. В качестве составных частей можно использовать типы из pyformlang (например, [конечные автоматы](https://pyformlang.readthedocs.io/en/latest/usage.html#finite-automata)). При проектировании этого типа необходимо помнить, что рекурсивные конечные автоматы будут использоваться в алгоритмах КС достижимости, основанных на линейной алгебре, а значит необходимо будет строить матрицы смежности. Здесь могут быть полезны результаты домашних работ по конечным автоматам.
- [x] Реализовать внутреннее представление для ECFG, пригодное как для дальнейшей конвертации в рекурсивный конечный автомат, так и для получения его из "внешних источников", таких, например, как преобразование из стандартного внутреннего представления КС грамматик в pyformlang.
- [x] Используя [возможности pyformlang для работы с контекстно-свободными грамматиками](https://pyformlang.readthedocs.io/en/latest/modules/context_free_grammar.html), реализовать **функцию** преобразования контекстно-свободной грамматики в стандартном формате pyformlang в ECFG.
  - Предусмотреть возможность получать исходную грамматику из различных источников. Например, прочитать из файла или получить из преобразования в ОНФХ.
- [x] Используя [возможности pyformlang для работы с контекстно-свободными грамматиками](https://pyformlang.readthedocs.io/en/latest/modules/context_free_grammar.html), [регулярными выражениями](https://pyformlang.readthedocs.io/en/latest/usage.html#regular-expression) и [конечными автоматами](https://pyformlang.readthedocs.io/en/latest/usage.html#finite-automata), реализовать **функцию** преобразования контекстно-свободной грамматики в ECFG в рекурсивный конечный автомат.
  - Предусмотреть возможность получать исходную грамматику из различных источников. Например, прочитать из файла, прочитать из строковой переменной, получить как результат работы какой-либо другой процедуры.
- [x] Реализовать **функцию** минимизации рекурсивного конечного автомата. Здесь под минимизацией понимается минимизация автомата для каждого нетерминала как конечного автомата над смешанным алфавитом.
- [x] Добавить необходимые тесты.